### PR TITLE
Allow config attributes to be used without a dependancy on mod settings by using strings or passing delegates directly

### DIFF
--- a/BepisModSettings/ConfigAttributes/ActionConfig.cs
+++ b/BepisModSettings/ConfigAttributes/ActionConfig.cs
@@ -8,6 +8,8 @@ public class ActionConfig(Delegate action)
 
     public object Invoke(params object[] args) => Action.DynamicInvoke(args);
 }
+/*
+TODO: implement these inside BepisPluginPage.cs, then uncomment
 
 public class ActionConfig<T>(Action<T> action) : ActionConfig(action)
 {
@@ -28,3 +30,4 @@ public class FuncConfig<T, TResult>(Func<T, TResult> func) : ActionConfig(func)
 {
     public TResult Invoke(T arg) => ((Func<T, TResult>)Action)(arg);
 }
+*/

--- a/BepisModSettings/ConfigAttributes/HiddenConfig.cs
+++ b/BepisModSettings/ConfigAttributes/HiddenConfig.cs
@@ -1,3 +1,12 @@
-﻿namespace BepisModSettings.ConfigAttributes;
+﻿using BepInEx.Configuration;
+using System.Linq;
 
-public class HiddenConfig { }
+namespace BepisModSettings.ConfigAttributes;
+
+public class HiddenConfig 
+{
+    public static bool IsHidden(ConfigEntryBase config)
+    {
+        return config?.Description?.Tags.Any(tag => tag is HiddenConfig || (tag as string) == "Hidden") ?? false;
+    }
+}

--- a/BepisModSettings/ConfigAttributes/ProtectedConfig.cs
+++ b/BepisModSettings/ConfigAttributes/ProtectedConfig.cs
@@ -1,8 +1,28 @@
-﻿namespace BepisModSettings.ConfigAttributes;
+﻿using BepInEx.Configuration;
+using System.Linq;
+
+namespace BepisModSettings.ConfigAttributes;
 
 public class ProtectedConfig(string maskString)
 {
     public ProtectedConfig() : this("*") { }
 
     public string MaskString { get; } = maskString;
+
+    public static string GetMask(ConfigEntryBase config)
+    {
+        if (config?.Description?.Tags == null) return null;
+        foreach (var tag in config.Description.Tags)
+        {
+            if(tag is ProtectedConfig protectedConfig)
+            {
+                return protectedConfig.MaskString;
+            }
+            else if(tag as string == "Protected")
+            {
+                return "*";
+            }
+        }
+        return null;
+    }
 }

--- a/BepisModSettings/DataFeeds/BepisPluginPage.cs
+++ b/BepisModSettings/DataFeeds/BepisPluginPage.cs
@@ -125,7 +125,7 @@ public static class BepisPluginPage
             List<string> added = new List<string>();
             foreach (ConfigEntryBase config in configFile.Values)
             {
-                if (!Plugin.ShowHidden.Value && config.Description.Tags.Any(x => x is HiddenConfig)) continue;
+                if (!Plugin.ShowHidden.Value && HiddenConfig.IsHidden(config)) continue;
 
                 Type valueType = config.SettingType;
 
@@ -182,7 +182,8 @@ public static class BepisPluginPage
                 {
                     DataFeedItem dummyField = null;
 
-                    if (config.Description.Tags.FirstOrDefault(x => x is ActionConfig) is ActionConfig action)
+                    var firstAction = config.Description.Tags.FirstOrDefault(x => x is ActionConfig || x is Action);
+                    if (firstAction != null)
                     {
                         DataFeedAction actionField = new DataFeedAction();
                         actionField.InitBase(key, path, groupingKeys, nameKey, descKey);
@@ -190,18 +191,20 @@ public static class BepisPluginPage
                         {
                             Button btn = syncDelegate.Slot.GetComponent<Button>();
                             if (btn == null) return;
-
-                            btn.LocalPressed += (_, _) => action.Invoke();
+                            if(firstAction is ActionConfig actionCofnig)
+                                btn.LocalPressed += (_, _) => actionCofnig.Invoke();
+                            else if (firstAction is Action action)
+                                btn.LocalPressed += (_, _) => action.Invoke();
                         });
 
                         dummyField = actionField;
                     }
 
                     bool customUi = false;
-                    if (config.Description.Tags.FirstOrDefault(x => x is CustomDataFeed) is CustomDataFeed customDataFeed)
+                    if (CustomDataFeed.GetCustomFeedMethod(config) is DataFeedMethod customDataFeed)
                     {
                         customUi = true;
-                        IAsyncEnumerable<DataFeedItem> datafeed = customDataFeed.Build(path, groupingKeys);
+                        IAsyncEnumerable<DataFeedItem> datafeed = customDataFeed(path, groupingKeys);
                         await foreach (DataFeedItem item in datafeed)
                         {
                             yield return item;

--- a/BepisModSettings/DataFeeds/DataFeedHelpers.cs
+++ b/BepisModSettings/DataFeeds/DataFeedHelpers.cs
@@ -70,12 +70,12 @@ public static class DataFeedHelpers
         valueField.InitBase($"{key}.{configKey.SettingType}", path, groupKeys, internalLocale.Key, internalLocale.Description);
         valueField.InitSetupValue(field =>
         {
-            if (!Plugin.ShowProtected.Value && configKey.Description.Tags.FirstOrDefault(x => x is ProtectedConfig) is ProtectedConfig protectedConfig)
+            if (!Plugin.ShowProtected.Value && ProtectedConfig.GetMask(configKey) is string mask)
             {
                 TextField textField = field.FindNearestParent<Slot>().FindParent(x => x.Name == "DataFeedValueField<string>", 5).GetComponentInChildren<TextField>();
                 textField.Text.ParseRichText.Value = false;
                 textField.Editor.Target.Undo.Value = false;
-                textField.Text.MaskPattern.Value = protectedConfig.MaskString;
+                textField.Text.MaskPattern.Value = mask;
             }
             
             field.SyncWithConfigKey(configKey);


### PR DESCRIPTION
For hidden config simply pass "Hidden".
For protected, it only supports the default * mask, and you can use "Protected"
For actions you just pass an Action delegate and the settings will pick it up.
For custom data feeds you can pass a `Func<IReadOnlyList<string>, IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>>`
(yes the type is very verbose, but modders don't have to type it in most of the time, and they can just use the modsettings dependancy if they don't want to use this thing)