### PR TITLE
Add more checks for Hidden Configs, Add Custom Nested Category Events

### DIFF
--- a/BepisModSettings/BepisModSettings.csproj
+++ b/BepisModSettings/BepisModSettings.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <Version>1.2.0</Version>
+        <Version>1.3.0</Version>
         <Authors>ResoniteModding</Authors>
         <TargetFramework>net9.0</TargetFramework>
         <Product>Bepis Mod Settings</Product>

--- a/BepisModSettings/BepisModSettings.csproj
+++ b/BepisModSettings/BepisModSettings.csproj
@@ -8,12 +8,12 @@
         <RepositoryUrl>https://github.com/ResoniteModding/$(AssemblyName)</RepositoryUrl>
         <PackageId>ResoniteModding.$(AssemblyName)</PackageId>
         <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <CopyToPlugins>false</CopyToPlugins>
+        <CopyToPlugins>true</CopyToPlugins>
         <ThunderstorePackable>true</ThunderstorePackable>
         <GamePath Condition="'$(ResonitePath)' != ''">$(ResonitePath)/</GamePath>
         <GamePath Condition="Exists('$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\')">$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\</GamePath>
         <GamePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GamePath>
-        <PluginTargetDir>$(GamePath)BepInEx\plugins\$(AssemblyName)</PluginTargetDir>
+        <PluginTargetDir>$(GamePath)BepInEx\plugins\ResoniteModding-$(AssemblyName)\$(AssemblyName)</PluginTargetDir>
         <RootNamespace>$(AssemblyName)</RootNamespace>
         <RestoreAdditionalProjectSources>
             https://nuget-modding.resonite.net/v3/index.json;

--- a/BepisModSettings/BepisModSettings.csproj
+++ b/BepisModSettings/BepisModSettings.csproj
@@ -13,7 +13,7 @@
         <GamePath Condition="'$(ResonitePath)' != ''">$(ResonitePath)/</GamePath>
         <GamePath Condition="Exists('$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\')">$(MSBuildProgramFiles32)\Steam\steamapps\common\Resonite\</GamePath>
         <GamePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</GamePath>
-        <PluginTargetDir>$(GamePath)BepInEx\plugins\ResoniteModding-$(AssemblyName)\$(AssemblyName)</PluginTargetDir>
+        <PluginTargetDir>$(GamePath)BepInEx\plugins\$(Authors)-$(AssemblyName)\$(AssemblyName)</PluginTargetDir>
         <RootNamespace>$(AssemblyName)</RootNamespace>
         <RestoreAdditionalProjectSources>
             https://nuget-modding.resonite.net/v3/index.json;

--- a/BepisModSettings/DataFeeds/BepisConfigsPage.cs
+++ b/BepisModSettings/DataFeeds/BepisConfigsPage.cs
@@ -441,18 +441,7 @@ public static class BepisConfigsPage
     {
         try
         {
-            ConfigFile configFile = null;
-
-            if (pluginId == "BepInEx.Core.Config")
-            {
-                configFile = ConfigFile.CoreConfig;
-            }
-            else if (NetChainloader.Instance.Plugins.TryGetValue(pluginId, out PluginInfo pluginInfo) && pluginInfo.Instance is BasePlugin plugin)
-            {
-                configFile = plugin.Config;
-            }
-
-            if (configFile == null) return;
+            if (!DataFeedHelpers.TryGetPluginData(pluginId, out ConfigFile configFile, out _)) return;
 
             foreach (ConfigEntryBase entry in configFile.Values)
             {

--- a/BepisModSettings/DataFeeds/BepisNestedCategoryPage.cs
+++ b/BepisModSettings/DataFeeds/BepisNestedCategoryPage.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
+using BepInEx.NET.Common;
 using Elements.Core;
 using FrooxEngine;
 
@@ -8,22 +10,44 @@ namespace BepisModSettings.DataFeeds;
 
 public static class BepisNestedCategoryPage
 {
+    public static event Func<IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>> CustomNestedCategoryPages;
+
     internal static async IAsyncEnumerable<DataFeedItem> Enumerate(IReadOnlyList<string> path)
     {
         await Task.CompletedTask;
 
-        if (BepisPluginPage.CategoryHandlers.TryGetValue(path[^1], out Func<IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>> handler))
+        string pluginId = path[1];
+
+        if (BepisConfigsPage.CategoryHandlers.TryGetValue(path[^1], out Func<IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>> flagsHandler))
         {
-            await foreach (DataFeedItem item in handler(path))
+            await foreach (DataFeedItem item in flagsHandler(path))
             {
                 yield return item;
             }
+
+            yield break;
         }
-        else
+
+        if (NetChainloader.Instance.Plugins.Values.All(x => x.Metadata.GUID != pluginId) && pluginId != "BepInEx.Core.Config")
         {
-            DataFeedLabel invalidCategory = new DataFeedLabel();
-            invalidCategory.InitBase("InvalidCategory", path, null, "Settings.BepInEx.Plugins.Error".AsLocaleKey());
-            yield return invalidCategory;
+            if (CustomNestedCategoryPages != null)
+            {
+                foreach (Delegate del in CustomNestedCategoryPages.GetInvocationList())
+                {
+                    if (del is not Func<IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>> customNestedHandler) continue;
+
+                    await foreach (DataFeedItem item in customNestedHandler(path))
+                    {
+                        yield return item;
+                    }
+                }
+            }
+
+            yield break;
         }
+
+        DataFeedLabel invalidCategory = new DataFeedLabel();
+        invalidCategory.InitBase("InvalidCategory", path, null, "Settings.BepInEx.Plugins.Error".AsLocaleKey());
+        yield return invalidCategory;
     }
 }

--- a/BepisModSettings/DataFeeds/BepisNestedCategoryPage.cs
+++ b/BepisModSettings/DataFeeds/BepisNestedCategoryPage.cs
@@ -18,17 +18,7 @@ public static class BepisNestedCategoryPage
 
         string pluginId = path[1];
 
-        if (BepisConfigsPage.CategoryHandlers.TryGetValue(path[^1], out Func<IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>> flagsHandler))
-        {
-            await foreach (DataFeedItem item in flagsHandler(path))
-            {
-                yield return item;
-            }
-
-            yield break;
-        }
-
-        if (NetChainloader.Instance.Plugins.Values.All(x => x.Metadata.GUID != pluginId) && pluginId != "BepInEx.Core.Config")
+        if (!DataFeedHelpers.DoesPluginExist(pluginId))
         {
             if (CustomNestedCategoryPages != null)
             {
@@ -41,6 +31,16 @@ public static class BepisNestedCategoryPage
                         yield return item;
                     }
                 }
+            }
+
+            yield break;
+        }
+
+        if (BepisConfigsPage.CategoryHandlers.TryGetValue(path[^1], out Func<IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>> flagsHandler))
+        {
+            await foreach (DataFeedItem item in flagsHandler(path))
+            {
+                yield return item;
             }
 
             yield break;

--- a/BepisModSettings/DataFeeds/BepisPluginsPage.cs
+++ b/BepisModSettings/DataFeeds/BepisPluginsPage.cs
@@ -6,13 +6,13 @@ using BepInEx;
 using BepInEx.NET.Common;
 using BepInExResoniteShim;
 using BepisLocaleLoader;
+using BepisModSettings.ConfigAttributes;
 using Elements.Core;
 using FrooxEngine;
-using FrooxEngine.UIX;
 
 namespace BepisModSettings.DataFeeds;
 
-public static class BepisSettingsPage
+public static class BepisPluginsPage
 {
     public static event Func<IReadOnlyList<string>, IAsyncEnumerable<DataFeedItem>> CustomPluginsPages;
 
@@ -37,7 +37,7 @@ public static class BepisSettingsPage
 
             field.Value = SearchString;
             field.Changed += _ => SearchString = field.Value;
-            slot.GetComponentInParents<TextEditor>().LocalEditingFinished += _ => DataFeedHelpers.RefreshSettingsScreen();
+            slot.GetComponentInParents<TextEditor>().LocalEditingFinished += _ => DataFeedHelpers.RefreshSettingsScreen(slot.GetComponentInParents<RootCategoryView>());
         });
         yield return searchField;
 
@@ -61,6 +61,8 @@ public static class BepisSettingsPage
             {
                 foreach (PluginInfo pluginInfo in filteredPlugins)
                 {
+                    bool isEmpty = false;
+                    if (pluginInfo.Instance is BasePlugin plugin) isEmpty = plugin.Config.Count == 0 || !plugin.Config.Values.Any(config => Plugin.ShowHidden.Value || !HiddenConfig.IsHidden(config));
                     BepInPlugin pMetadata = MetadataHelper.GetMetadata(pluginInfo.Instance) ?? pluginInfo.Metadata;
                     ResonitePlugin resonitePlugin = pMetadata as ResonitePlugin;
 
@@ -70,7 +72,7 @@ public static class BepisSettingsPage
                     string pluginGuid = metaData.ID;
                     string pluginAuthor = metaData.Author;
 
-                    LocaleString nameKey = pluginName;
+                    LocaleString nameKey = isEmpty ? $"<color=#a8a8a8>{pluginName}</color>" : pluginName;
                     LocaleString description = $"{pluginName} ({metaData.Version}){(!string.IsNullOrEmpty(pluginAuthor) ? $"\nby \"{pluginAuthor}\"" : "")}\n\n{pluginGuid}";
 
                     if (LocaleLoader.PluginsWithLocales.Contains(pluginInfo))
@@ -83,8 +85,11 @@ public static class BepisSettingsPage
                         LocaleLoader.AddLocaleString($"Settings.{pluginGuid}.Breadcrumb", pluginName, authors: PluginMetadata.AUTHORS);
                     }
 
+                    if (isEmpty) nameKey = nameKey.SetFormat("<color=#a8a8a8>{0}</color>");
+
                     DataFeedCategory loadedPlugin = new DataFeedCategory();
                     loadedPlugin.InitBase(pluginGuid, path, loadedPluginsGroup, nameKey, description);
+                    if (Plugin.SortEmptyPages.Value && isEmpty) loadedPlugin.InitSorting(1);
                     yield return loadedPlugin;
                 }
             }
@@ -143,8 +148,11 @@ public static class BepisSettingsPage
         {
             if (!Plugin.ShowEmptyPages.Value)
             {
-                if (plugin.Instance is BasePlugin plug && plug.Config.Count == 0)
-                    return false;
+                if (plugin.Instance is BasePlugin plug)
+                {
+                    if (plug.Config.Count == 0 || !plug.Config.Values.Any(config => Plugin.ShowHidden.Value || !HiddenConfig.IsHidden(config)))
+                        return false;
+                }
             }
 
             if (string.IsNullOrWhiteSpace(searchString))

--- a/BepisModSettings/DataFeeds/BepisPluginsPage.cs
+++ b/BepisModSettings/DataFeeds/BepisPluginsPage.cs
@@ -41,9 +41,9 @@ public static class BepisPluginsPage
         });
         yield return searchField;
 
-        DataFeedGroup plguinsGroup = new DataFeedGroup();
-        plguinsGroup.InitBase("BepInExPlugins", path, null, "Settings.BepInEx.Plugins".AsLocaleKey());
-        yield return plguinsGroup;
+        DataFeedGroup pluginsGroup = new DataFeedGroup();
+        pluginsGroup.InitBase("BepInExPlugins", path, null, "Settings.BepInEx.Plugins".AsLocaleKey());
+        yield return pluginsGroup;
 
         DataFeedGrid pluginsGrid = new DataFeedGrid();
         pluginsGrid.InitBase("PluginsGrid", path, ["BepInExPlugins"], "Settings.BepInEx.LoadedPlugins".AsLocaleKey());
@@ -61,12 +61,9 @@ public static class BepisPluginsPage
             {
                 foreach (PluginInfo pluginInfo in filteredPlugins)
                 {
-                    bool isEmpty = false;
-                    if (pluginInfo.Instance is BasePlugin plugin) isEmpty = plugin.Config.Count == 0 || !plugin.Config.Values.Any(config => Plugin.ShowHidden.Value || !HiddenConfig.IsHidden(config));
-                    BepInPlugin pMetadata = MetadataHelper.GetMetadata(pluginInfo.Instance) ?? pluginInfo.Metadata;
-                    ResonitePlugin resonitePlugin = pMetadata as ResonitePlugin;
+                    bool isEmpty = DataFeedHelpers.IsEmpty(pluginInfo.Instance);
 
-                    ModMeta metaData = new ModMeta(pMetadata.Name, pMetadata.Version.ToString(), pMetadata.GUID, resonitePlugin?.Author, resonitePlugin?.Link);
+                    ModMeta metaData = pluginInfo.GetMetadata();
 
                     string pluginName = metaData.Name;
                     string pluginGuid = metaData.ID;
@@ -148,20 +145,14 @@ public static class BepisPluginsPage
         {
             if (!Plugin.ShowEmptyPages.Value)
             {
-                if (plugin.Instance is BasePlugin plug)
-                {
-                    if (plug.Config.Count == 0 || !plug.Config.Values.Any(config => Plugin.ShowHidden.Value || !HiddenConfig.IsHidden(config)))
-                        return false;
-                }
+                if (DataFeedHelpers.IsEmpty(plugin.Instance))
+                    return false;
             }
 
             if (string.IsNullOrWhiteSpace(searchString))
                 return true;
 
-            BepInPlugin pMetadata = MetadataHelper.GetMetadata(plugin.Instance) ?? plugin.Metadata;
-            ResonitePlugin resonitePlugin = pMetadata as ResonitePlugin;
-
-            ModMeta metadata = new ModMeta(pMetadata.Name, pMetadata.Version.ToString(), pMetadata.GUID, resonitePlugin?.Author, resonitePlugin?.Link);
+            ModMeta metadata = plugin.GetMetadata();
 
             if (metadata.Name.Contains(searchString, StringComparison.InvariantCultureIgnoreCase))
                 return true;

--- a/BepisModSettings/DataFeeds/DataFeedHelpers.cs
+++ b/BepisModSettings/DataFeeds/DataFeedHelpers.cs
@@ -546,14 +546,14 @@ public static class DataFeedHelpers
         }
     }
 
-    public static bool RefreshSettingsScreen()
+    public static bool RefreshSettingsScreen(RootCategoryView rcv = null)
     {
         if (_isUpdatingSettings) return false;
 
         try
         {
             _isUpdatingSettings = true;
-            RootCategoryView rcv = GetRootCategoryView();
+            rcv ??= GetRootCategoryView();
             if (rcv == null)
             {
                 _isUpdatingSettings = false;

--- a/BepisModSettings/DataFeeds/DataFeedHelpers.cs
+++ b/BepisModSettings/DataFeeds/DataFeedHelpers.cs
@@ -14,7 +14,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
+using BepInEx;
 using BepInEx.Configuration;
+using BepInEx.NET.Common;
+using BepInExResoniteShim;
 using BepisModSettings.ConfigAttributes;
 using Elements.Assets;
 using Elements.Core;
@@ -343,7 +346,7 @@ public static class DataFeedHelpers
                         betterInnterInterfaceSlot.PersistentSelf = false;
 
                         betterInnterInterfaceSlot.FindChildInHierarchy("Button")?.Parent.Destroy();
-                        
+
                         FeedItemInterface injectedInnerContainerItem = betterInnterInterfaceSlot.GetComponent<FeedItemInterface>();
                         templatesRoot.ForeachComponentInChildren<FeedItemInterface>(interface2 =>
                         {
@@ -370,6 +373,48 @@ public static class DataFeedHelpers
             Plugin.Log.LogError($"Error in EnsureBetterInnerContainerItem: {e}");
         }
     }*/
+
+    public static bool IsEmpty(object instance) => instance is BasePlugin plug && IsEmpty(plug);
+    public static bool IsEmpty(BasePlugin plug) => plug.Config != null && IsEmpty(plug.Config);
+    public static bool IsEmpty(ConfigFile config) => config.Count == 0 || config.Values.All(configIn => !Plugin.ShowHidden.Value && HiddenConfig.IsHidden(configIn));
+    
+    public static bool DoesPluginExist(string pluginId) => NetChainloader.Instance.Plugins.ContainsKey(pluginId) || pluginId == "BepInEx.Core.Config";
+
+    public static ModMeta GetMetadata(this PluginInfo pluginInfo)
+    {
+        BepInPlugin metadata = MetadataHelper.GetMetadata(pluginInfo.Instance) ?? pluginInfo.Metadata;
+        ResonitePlugin resoPlugin = metadata as ResonitePlugin;
+
+        string assCo = resoPlugin?.Author;
+        string assUrl = resoPlugin?.Link;
+
+        if (pluginInfo.Instance is BasePlugin plug)
+        {
+            assCo ??= plug.GetType().Assembly.GetCustomAttribute<AssemblyCompanyAttribute>()?.Company;
+            assUrl ??= plug.GetType().Assembly.GetCustomAttributes<AssemblyMetadataAttribute>().FirstOrDefault(a => a.Key.Contains("url", StringComparison.CurrentCultureIgnoreCase))?.Value;
+        }
+
+        return new ModMeta(metadata.Name, metadata.Version.ToString(), metadata.GUID, assCo, assUrl);
+    }
+
+    public static bool TryGetPluginData(string pluginId, out ConfigFile config, out ModMeta meta)
+    {
+        config = null;
+        meta = default;
+
+        if (pluginId == "BepInEx.Core.Config")
+        {
+            config = ConfigFile.CoreConfig;
+            meta = new ModMeta("BepInEx Core Config", Utility.BepInExVersion.ToString(), "BepInEx.Core", "Bepis", "https://github.com/ResoniteModding/BepisLoader");
+        }
+        else if (NetChainloader.Instance.Plugins.TryGetValue(pluginId, out PluginInfo pluginInfo) && pluginInfo.Instance is BasePlugin plugin)
+        {
+            config = plugin.Config;
+            meta = pluginInfo.GetMetadata();
+        }
+
+        return config != null;
+    }
 
     public static async IAsyncEnumerable<DataFeedItem> AsAsyncEnumerable(this DataFeedItem item)
     {

--- a/BepisModSettings/DataFeeds/DataFeedInjector.cs
+++ b/BepisModSettings/DataFeeds/DataFeedInjector.cs
@@ -13,13 +13,13 @@ public static class DataFeedInjector
         // Handle root category
         if (path.Count == 1)
         {
-            return BepisSettingsPage.Enumerate(path);
+            return BepisPluginsPage.Enumerate(path);
         }
 
         // Handle plugin configs page
         if (path.Count == 2)
         {
-            return BepisPluginPage.Enumerate(path);
+            return BepisConfigsPage.Enumerate(path);
         }
 
         // Handle nested category page
@@ -31,7 +31,7 @@ public static class DataFeedInjector
         return original;
     }
 
-    internal static async IAsyncEnumerable<DataFeedItem> NotUserspaceEnumerator(IReadOnlyList<string> path)
+    internal static async IAsyncEnumerable<DataFeedItem> NotUserspaceEnumerable(IReadOnlyList<string> path)
     {
         await Task.CompletedTask;
 

--- a/BepisModSettings/Plugin.cs
+++ b/BepisModSettings/Plugin.cs
@@ -50,7 +50,7 @@ public class Plugin : BasePlugin
         ShowProtected = Config.Bind("General", "ShowProtected", false, "Whether to show protected Configs");
 
         ShowEmptyPages = Config.Bind("General", "ShowEmptyPages", true, "Whether to show category buttons for pages which would have no content");
-        SortEmptyPages = Config.Bind("General", "SortEmptyPages", true, "Whether to sort empty pages to the bottom o the list");
+        SortEmptyPages = Config.Bind("General", "SortEmptyPages", true, "Whether to sort empty pages to the bottom of the list");
 
         TestAction = Config.Bind("Tests", "TestAction", default(dummy), new ConfigDescription("TestAction", null, new ActionConfig(() => Log.LogError("OneOfThem"))));
         TestProtected = Config.Bind("Tests", "TestProtected", "AWAWAWAWA THIS IS A TEST MESSAGE", new ConfigDescription("TestProtected", null, new ProtectedConfig()));
@@ -64,7 +64,7 @@ public class Plugin : BasePlugin
         ResoniteHooks.OnEngineReady += () =>
         {
             FieldInfo categoryField = AccessTools.Field(typeof(Settings), "_categoryInfos");
-            if (categoryField != null && categoryField.GetValue(null) is Dictionary<string, SettingCategoryInfo> categoryInfos)
+            if (categoryField?.GetValue(null) is Dictionary<string, SettingCategoryInfo> categoryInfos)
             {
                 SettingCategoryInfo bepInExCategory = new SettingCategoryInfo(new Uri("https://avatars.githubusercontent.com/u/39589027?s=200&v=4.png"), 99L);
                 bepInExCategory.InitKey("BepInEx");

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ A [Resonite](https://resonite.com/) mod that lets you edit your mod settings in 
 Example home page:<img width="1619" height="845" alt="image" src="https://github.com/user-attachments/assets/f978a2b4-5ff0-450c-b85e-2752b8057b43" />
 Typical configuration screen:<img width="1891" height="834" alt="image" src="https://github.com/user-attachments/assets/6662da50-3d01-4032-a504-01660dfecd86" />
 Flags enum:<img width="1625" height="850" alt="image" src="https://github.com/user-attachments/assets/1e350606-5c78-42a7-a39f-2d275045d64c" />
-Fallback config strings:<img width="1559" height="829" alt="image" src="https://github.com/user-attachments/assets/cbeca447-8b64-46a5-a5dd-f974abfd68fd" />
 Configuration page footer:<img width="1358" height="480" alt="image" src="https://github.com/user-attachments/assets/3884946a-54cd-4ce9-969d-94cdce5a9d05" />
 
 


### PR DESCRIPTION
This PR adds multiple checks for hidden configs, which will either hide them/recolor them, and also remove/hide mods with just hidden configs, and remove/hide sections with only hidden configs

This could be really cleaned up with some code deduplication, but as of now this works.

This also adds events for CustomNestedCategories, so Categories over the depth of 3 can actually be used for Settings Addons